### PR TITLE
Fixed Typo at Unprotect-Datum.ps1

### DIFF
--- a/Datum.ProtectedData/public/Unprotect-Datum.ps1
+++ b/Datum.ProtectedData/public/Unprotect-Datum.ps1
@@ -107,7 +107,7 @@ function Unprotect-Datum {
         }
         Write-verbose "Calling Unprotect-Data $($PSCmdlet.ParameterSetName)"
         Switch ($PSCmdlet.ParameterSetName) {
-            'ByCertificae' { $UnprotectDataParams.Add('Certificate', $Certificate)}
+            'ByCertificate' { $UnprotectDataParams.Add('Certificate', $Certificate)}
             'ByPassword' { $UnprotectDataParams.Add('Password', $Password)      }
         }
         Unprotect-Data @UnprotectDataParams


### PR DESCRIPTION
Fixes a Typo which skips the Certificate Parameter for Unprotect-Data.
Fixes Issue: #5 